### PR TITLE
Support passing Authorization headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>2.121.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <artifactory-maven-plugin.version>2.6.1</artifactory-maven-plugin.version>
     <project.build.testSourceDirectory>src/test/java</project.build.testSourceDirectory>

--- a/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
+++ b/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
@@ -22,6 +22,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -51,6 +52,8 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -241,6 +244,12 @@ public class HttpRetriever extends LibraryRetriever {
         try (CloseableHttpClient client = HttpClients.createDefault()) {
             HttpClientContext context = getHttpClientContext(passwordCredentials);
             HttpGet get = new HttpGet(new URL(sourceURL).toURI());
+            if (passwordCredentials != null) {
+                String encoded = Base64.getEncoder()
+                        .encodeToString((passwordCredentials.getUsername() + ":" + passwordCredentials.getPassword())
+                                .getBytes(StandardCharsets.UTF_8));
+                get.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded);
+            }
             try (CloseableHttpResponse response = client.execute(get, context)) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode != HttpStatus.SC_OK) {


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>

Artifactory version: 6.9.1

I was not able to get the code to work with Artifactory using authentication and it seemed the code would only use authentication if the server requests one, and it seems that's not the case with artifactory. So I'm setting `Authorization` header explicitly if credentials are used.