### PR TITLE
Preemptive auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.amadeus.jenkins.plugins</groupId>
   <artifactId>workflow-cps-global-lib-http</artifactId>
-  <version>1.2.4-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Shared Groovy Libraries through HTTP retrieval</name>
   <url>https://wiki.jenkins.io/display/JENKINS/HTTP+Shared+Libraries+Retriever+plugin</url>

--- a/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
+++ b/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
@@ -3,13 +3,11 @@ package com.amadeus.jenkins.plugins.workflow.libs;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import com.google.common.annotations.VisibleForTesting;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
 import hudson.model.Item;
-import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
@@ -22,6 +20,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.client.AuthCache;
@@ -92,33 +91,42 @@ public class HttpRetriever extends LibraryRetriever {
      * Name of the credential to use if we need authentication to download the library archive
      */
     private final String credentialsId;
-    private final Node jenkins;
 
     /**
-     * Constructor used for JUnits
-     *
-     * @param httpURL       URL template where the library can be downloaded
-     * @param credentialsId The credentials ID that can be used to do an authenticated download
-     * @param jenkins       The representation of the Jenkins server
+     * To force using authentication when downloading the library archive. Can be useful if the HTTP server
+     * hides the existence of unauthorized resources by sending a 404
+     * response (not found) to requests for resources that are not accessible by the user. Otherwise,
+     * the response implies that the resource exists, but is protected, by requesting authentication
+     * for anonymous requests (401), or by denying an authenticated request for unauthorized users.
      */
-    @VisibleForTesting
-    HttpRetriever(String httpURL, String credentialsId, Node jenkins) {
-        this.httpURL = httpURL;
-        this.credentialsId = credentialsId;
-        this.jenkins = jenkins;
-    }
+    private final boolean preemptiveAuth;
 
     /**
      * Constructor
      *
-     * @param httpURL       URL template where the library can be downloaded
-     * @param credentialsId The credentials ID that can be used to do an authenticated download
+     * @param httpURL        URL template where the library can be downloaded
+     * @param credentialsId  The credentials ID that can be used to do an authenticated download
+     * @param preemptiveAuth Send the basic authentication response before the server gives an unauthorized response
      */
     @DataBoundConstructor
-    public HttpRetriever(@Nonnull String httpURL, @Nonnull String credentialsId) {
+    public HttpRetriever(@Nonnull String httpURL, @Nonnull String credentialsId, boolean preemptiveAuth) {
         this.httpURL = httpURL;
         this.credentialsId = credentialsId;
-        this.jenkins = Jenkins.get();
+        this.preemptiveAuth = preemptiveAuth;
+    }
+
+    Jenkins getJenkins() {
+        return Jenkins.get();
+    }
+
+    /**
+     * Accessor for know if the plugin should send the basic authentication response
+     * before the server gives an unauthorized response
+     *
+     * @return if the plugin should always send the basic authentication
+     */
+    public boolean isPreemptiveAuth() {
+        return this.preemptiveAuth;
     }
 
     /**
@@ -229,11 +237,37 @@ public class HttpRetriever extends LibraryRetriever {
         StandardUsernameCredentials credentials = findCredentialById(credentialsId, StandardUsernameCredentials.class, run);
         if (credentials instanceof UsernamePasswordCredentials) {
             passwordCredentials = (UsernamePasswordCredentials) credentials;
-            track(jenkins, passwordCredentials);
+            track(getJenkins(), passwordCredentials);
         } else {
             passwordCredentials = null;
         }
         return passwordCredentials;
+    }
+
+    UsernamePasswordCredentials initPasswordCredentials() {
+        if (!getJenkins().hasPermission(Jenkins.ADMINISTER)) {
+            return null;
+        }
+        UsernamePasswordCredentials passwordCredentials = findCredentials(credentialsId);
+        if (passwordCredentials != null) {
+            track(getJenkins(), passwordCredentials);
+            return passwordCredentials;
+        }
+        return null;
+    }
+
+    UsernamePasswordCredentials findCredentials(String credentialsId) {
+        List<StandardUsernameCredentials> standardUsernameCredentials = lookupCredentials(
+                StandardUsernameCredentials.class, getJenkins(), ACL.SYSTEM, Collections.emptyList());
+        for (StandardUsernameCredentials standardUsernameCredential : standardUsernameCredentials) {
+            if (standardUsernameCredential instanceof UsernamePasswordCredentials) {
+                UsernamePasswordCredentials passwordCredentials = (UsernamePasswordCredentials) standardUsernameCredential;
+                if (standardUsernameCredential.getId() != null && standardUsernameCredential.getId().equals(credentialsId)) {
+                    return passwordCredentials;
+                }
+            }
+        }
+        return null;
     }
 
     private void unzip(WorkspaceList.Lease lease, FilePath filePath) throws IOException, InterruptedException {
@@ -245,31 +279,21 @@ public class HttpRetriever extends LibraryRetriever {
     private FilePath download(String sourceURL, UsernamePasswordCredentials passwordCredentials,
                               String zipFileName, WorkspaceList.Lease lease)
             throws IOException, URISyntaxException {
-
-        // Copying it in workspace
-        CredentialsProvider credentialsProvider = getCredentialsProvider(passwordCredentials);
+        URL url = new URL(sourceURL);
+        HttpGet get = new HttpGet(url.toURI());
         try (CloseableHttpClient client = HttpClients.createDefault()) {
-            URL url = new URL(sourceURL);
-            HttpClientContext context = getHttpClientContext(credentialsProvider);
-            HttpGet get = new HttpGet(url.toURI());
+            HttpClientContext context = getHttpClientContext(passwordCredentials, url);
             try (CloseableHttpResponse response = client.execute(get, context)) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode != HttpStatus.SC_OK) {
-                    setPreemptiveAuth(context, url);
-                    try (CloseableHttpResponse preemptiveResponse = client.execute(get, context)) {
-                        statusCode = preemptiveResponse.getStatusLine().getStatusCode();
-                        if (statusCode != HttpStatus.SC_OK) {
-                            throw new IOException("Failed to download " + sourceURL + ". Returned code: " + statusCode);
-                        }
-                        return writeResponseToFile(zipFileName, lease, preemptiveResponse);
-                    }
+                    throw new IOException("Failed to download " + sourceURL + ". Returned code: " + statusCode);
                 }
                 return writeResponseToFile(zipFileName, lease, response);
             }
         }
     }
 
-    private FilePath writeResponseToFile(String zipFileName, WorkspaceList.Lease lease, CloseableHttpResponse response) throws IOException {
+    private FilePath writeResponseToFile(String zipFileName, WorkspaceList.Lease lease, HttpResponse response) throws IOException {
         HttpEntity entity = response.getEntity();
         try (InputStream inputStream = entity.getContent()) {
             String wholeFilenameWithTargetPath = lease.path.child(zipFileName).getRemote();
@@ -304,9 +328,9 @@ public class HttpRetriever extends LibraryRetriever {
     private FilePath getDownloadFolder(String name, Run<?, ?> run) throws IOException {
         FilePath dir;
         if (run.getParent() instanceof TopLevelItem) {
-            FilePath baseWorkspace = jenkins.getWorkspaceFor((TopLevelItem) run.getParent());
+            FilePath baseWorkspace = getJenkins().getWorkspaceFor((TopLevelItem) run.getParent());
             if (baseWorkspace == null) {
-                throw new IOException(jenkins.getDisplayName() + " may be offline");
+                throw new IOException(getJenkins().getDisplayName() + " may be offline");
             }
             dir = baseWorkspace.withSuffix(getFilePathSuffix() + "libs").child(name);
         } else {
@@ -316,9 +340,9 @@ public class HttpRetriever extends LibraryRetriever {
     }
 
     Computer getSlave() throws IOException {
-        Computer computer = jenkins.toComputer();
+        Computer computer = getJenkins().toComputer();
         if (computer == null) {
-            throw new IOException(jenkins.getDisplayName() + " may be offline");
+            throw new IOException(getJenkins().getDisplayName() + " may be offline");
         }
         return computer;
     }
@@ -344,7 +368,6 @@ public class HttpRetriever extends LibraryRetriever {
     @Override
     public FormValidation validateVersion(@Nonnull String name, @Nonnull String version) {
         String replacedVersionURL = convertURLVersion(httpURL, name, version);
-
         try {
             URL newURL = new URL(replacedVersionURL);
 
@@ -396,20 +419,25 @@ public class HttpRetriever extends LibraryRetriever {
     }
 
     private int checkURL(URL url) throws IOException, URISyntaxException {
+        UsernamePasswordCredentials passwordCredentials = initPasswordCredentials();
+        HttpHead head = new HttpHead(url.toURI());
         try (CloseableHttpClient client = HttpClients.createDefault()) {
-            HttpClientContext context = HttpClientContext.create();
-            HttpHead head = new HttpHead(url.toURI());
+            HttpClientContext context = getHttpClientContext(passwordCredentials, url);
             try (CloseableHttpResponse response = client.execute(head, context)) {
                 return response.getStatusLine().getStatusCode();
             }
         }
     }
 
-    private HttpClientContext getHttpClientContext(CredentialsProvider credentialsProvider) {
+    private HttpClientContext getHttpClientContext(UsernamePasswordCredentials passwordCredentials, URL url) {
         HttpClientContext context = HttpClientContext.create();
         // Authenticate if credentials are given
-        if (credentialsProvider != null) {
+        if (passwordCredentials != null) {
+            CredentialsProvider credentialsProvider = getCredentialsProvider(passwordCredentials);
             context.setCredentialsProvider(credentialsProvider);
+        }
+        if (isPreemptiveAuth()) {
+            setPreemptiveAuth(context, url);
         }
         return context;
     }

--- a/src/main/resources/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever/config.jelly
+++ b/src/main/resources/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever/config.jelly
@@ -35,4 +35,8 @@ THE SOFTWARE.
     <c:select/>
 </f:entry>
 
+<f:entry title="Use preemptive authentication?" field="preemptiveAuth" description="If checked, uses preemptive authentication.">
+  <f:checkbox/>
+</f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever/help-preemptiveAuth.html
+++ b/src/main/resources/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever/help-preemptiveAuth.html
@@ -1,0 +1,6 @@
+<div>
+    To force using authentication when downloading the library archive. Can be useful if the HTTP server hides the
+    existence of unauthorized resources by sending a 404 response (not found) to requests for resources that are not
+    accessible by the user. Otherwise, the response implies that the resource exists, but is protected, by requesting
+    authentication for anonymous requests (401), or by denying an authenticated request for unauthorized users.
+</div>

--- a/src/test/java/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest.java
+++ b/src/test/java/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest.java
@@ -1,53 +1,118 @@
 package com.amadeus.jenkins.plugins.workflow.libs;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.ExtensionList;
-import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigurationRoundtripTest {
-  @Rule
-  public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  private UsernamePasswordCredentialsImpl credentials;
-  private GlobalLibraries globalLibraries;
+    private UsernamePasswordCredentialsImpl credentials;
+    private GlobalLibraries globalLibraries;
 
-  @Before
-  public void setUp() {
-    credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "someCredentials", null, "username", "password");
-    ExtensionList.lookupSingleton(SystemCredentialsProvider.class).getCredentials().add(credentials);
-    globalLibraries = ExtensionList.lookupSingleton(GlobalLibraries.class);
-  }
+    @Before
+    public void setUp() {
+        credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "someCredentials", null, "username", "password");
+        ExtensionList.lookupSingleton(SystemCredentialsProvider.class).getCredentials().add(credentials);
+        globalLibraries = ExtensionList.lookupSingleton(GlobalLibraries.class);
+    }
 
-  @Test
-  public void testConfigurationRoundtrip() throws Exception {
-    assertThat(globalLibraries.getLibraries()).isEmpty();
-    LibraryConfiguration originalTestLib = new LibraryConfiguration(
-      "foo",
-      new HttpRetriever("http://example.com/", credentials.getId())
-    );
-    globalLibraries.getLibraries().add(originalTestLib);
-    j.configRoundtrip();
+    @Test
+    public void testConfigurationRoundtrip() throws Exception {
+        assertThat(globalLibraries.getLibraries()).isEmpty();
+        LibraryConfiguration originalTestLib = new LibraryConfiguration(
+                "foo",
+                new HttpRetriever("http://example.com/", credentials.getId(), true)
+        );
+        globalLibraries.getLibraries().add(originalTestLib);
+        j.configRoundtrip();
 
-    List<LibraryConfiguration> libs = globalLibraries.getLibraries();
-    assertThat(libs).hasSize(1);
-    LibraryConfiguration testLib = globalLibraries.getLibraries().get(0);
-    assertThat(testLib).isNotSameAs(originalTestLib);
-    assertThat(testLib.getName()).isEqualTo("foo");
-    assertThat(testLib.getRetriever()).isExactlyInstanceOf(HttpRetriever.class);
-    HttpRetriever retriever = (HttpRetriever) testLib.getRetriever();
-    assertThat(retriever.getHttpURL()).isEqualTo("http://example.com/");
-    assertThat(retriever.getCredentialsId())
-      .isNotNull()
-      .isEqualTo(credentials.getId());
-  }
+        List<LibraryConfiguration> libs = globalLibraries.getLibraries();
+        assertThat(libs).hasSize(1);
+        LibraryConfiguration testLib = globalLibraries.getLibraries().get(0);
+        assertThat(testLib).isNotSameAs(originalTestLib);
+        assertThat(testLib.getName()).isEqualTo("foo");
+        assertThat(testLib.getRetriever()).isExactlyInstanceOf(HttpRetriever.class);
+        HttpRetriever retriever = (HttpRetriever) testLib.getRetriever();
+        assertThat(retriever.getHttpURL()).isEqualTo("http://example.com/");
+        assertThat(retriever.getCredentialsId())
+                .isNotNull()
+                .isEqualTo(credentials.getId());
+        assertThat(retriever.isPreemptiveAuth()).isTrue();
+    }
+
+    @Test
+    @LocalData
+    public void testFormatDidNotChange() throws Exception {
+        String previousConfig = getConfig();
+        assertThat(previousConfig).isNotNull();
+        assertThat(previousConfig).isNotEmpty();
+
+        LibraryConfiguration lib = new LibraryConfiguration(
+                "foo",
+                new HttpRetriever("http://example.com/", credentials.getId(), true)
+        );
+        globalLibraries.getLibraries().clear();
+        globalLibraries.getLibraries().add(lib);
+        j.configRoundtrip();
+        String currentConfig = getConfig();
+
+        String message = "Your config format changed. If it is intentional and necessary:\n";
+        message += " - update this test with new test data that reflects your new data format\n";
+        message += " - create test to make sure that new code can cope with old data format" +
+                " (testConfigurationRoundtripXXX)";
+        message += "\n\n";
+        message += "Old config:\n" + previousConfig;
+        message += "\n\n";
+        message += "New config:\n" + currentConfig;
+        message += "\n\n";
+
+        assertThat(previousConfig).withFailMessage(message).isXmlEqualTo(currentConfig);
+    }
+
+    private String getConfig() throws IOException {
+        String previousConfig = null;
+        assertThat(globalLibraries.getLibraries()).isNotEmpty();
+        File configFile = new File(j.jenkins.getRootDir(), globalLibraries.getId() + ".xml");
+        assertThat(configFile).exists();
+        try (FileInputStream input = new FileInputStream(configFile)) {
+            previousConfig = IOUtils.toString(input);
+        }
+        return previousConfig;
+    }
+
+
+    @Test
+    @LocalData
+    public void testConfigurationRoundtrip123() throws Exception {
+        assertThat(globalLibraries.getLibraries()).isNotEmpty();
+        List<LibraryConfiguration> libs = globalLibraries.getLibraries();
+        assertThat(libs).hasSize(1);
+        LibraryConfiguration testLib = globalLibraries.getLibraries().get(0);
+        assertThat(testLib.getName()).isEqualTo("foo");
+        assertThat(testLib.getRetriever()).isExactlyInstanceOf(HttpRetriever.class);
+        HttpRetriever retriever = (HttpRetriever) testLib.getRetriever();
+        assertThat(retriever.getHttpURL()).isEqualTo("http://example.com/");
+        assertThat(retriever.getCredentialsId())
+                .isNotNull()
+                .isEqualTo(credentials.getId());
+        assertThat(retriever.isPreemptiveAuth()).isFalse();
+    }
 }

--- a/src/test/resources/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest/testConfigurationRoundtrip123/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
+++ b/src/test/resources/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest/testConfigurationRoundtrip123/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
@@ -1,0 +1,57 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<org.jenkinsci.plugins.workflow.libs.GlobalLibraries>
+    <libraries>
+        <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+            <name>foo</name>
+            <retriever class="com.amadeus.jenkins.plugins.workflow.libs.HttpRetriever">
+                <httpURL>http://example.com/</httpURL>
+                <credentialsId>someCredentials</credentialsId>
+                <jenkins class="hudson.model.Hudson">
+                    <disabledAdministrativeMonitors/>
+                    <version>2.121.3</version>
+                    <installStateName>TEST</installStateName>
+                    <numExecutors>2</numExecutors>
+                    <mode>NORMAL</mode>
+                    <useSecurity>true</useSecurity>
+                    <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+                    <securityRealm class="hudson.security.SecurityRealm$None"/>
+                    <disableRememberMe>false</disableRememberMe>
+                    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+                    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}</workspaceDir>
+                    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+                    <jdks>
+                        <hudson.model.JDK>
+                            <name>default</name>
+                            <home>/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre</home>
+                            <properties/>
+                        </hudson.model.JDK>
+                    </jdks>
+                    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+                    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+                    <clouds/>
+                    <quietPeriod>5</quietPeriod>
+                    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+                    <views>
+                        <hudson.model.AllView>
+                            <owner class="hudson.model.Hudson" reference="../../.."/>
+                            <name>all</name>
+                            <filterExecutors>false</filterExecutors>
+                            <filterQueue>false</filterQueue>
+                            <properties class="hudson.model.View$PropertyList"/>
+                        </hudson.model.AllView>
+                    </views>
+                    <primaryView>all</primaryView>
+                    <slaveAgentPort>0</slaveAgentPort>
+                    <label></label>
+                    <crumbIssuer class="org.jvnet.hudson.test.TestCrumbIssuer"/>
+                    <nodeProperties/>
+                    <globalNodeProperties/>
+                    <noUsageStatistics>true</noUsageStatistics>
+                </jenkins>
+            </retriever>
+            <implicit>false</implicit>
+            <allowVersionOverride>true</allowVersionOverride>
+            <includeInChangesets>true</includeInChangesets>
+        </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+    </libraries>
+</org.jenkinsci.plugins.workflow.libs.GlobalLibraries>

--- a/src/test/resources/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest/testFormatDidNotChange/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
+++ b/src/test/resources/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest/testFormatDidNotChange/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
@@ -1,0 +1,16 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<org.jenkinsci.plugins.workflow.libs.GlobalLibraries>
+  <libraries>
+    <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+      <name>foo</name>
+      <retriever class="com.amadeus.jenkins.plugins.workflow.libs.HttpRetriever">
+        <httpURL>http://example.com/</httpURL>
+        <credentialsId>someCredentials</credentialsId>
+        <preemptiveAuth>true</preemptiveAuth>
+      </retriever>
+      <implicit>false</implicit>
+      <allowVersionOverride>true</allowVersionOverride>
+      <includeInChangesets>true</includeInChangesets>
+    </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+  </libraries>
+</org.jenkinsci.plugins.workflow.libs.GlobalLibraries>


### PR DESCRIPTION
* Improves the test download done when changing the settings in the Admin section
* Gives the possibility to specify Preemptive authentication (useful for examples when Artifactory is set to send a 404 when auth is required instead of a 401)
* Fixes https://github.com/AmadeusITGroup/workflow-cps-global-lib-http-plugin/issues/8