### PR TITLE
Also list credentials at folder level #patch

### DIFF
--- a/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
+++ b/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
@@ -487,9 +487,8 @@ public class HttpRetriever extends LibraryRetriever {
                     return result.includeCurrentValue(credentialsId);
                 }
             }
-
             List<StandardUsernameCredentials> standardUsernameCredentials = lookupCredentials(
-                    StandardUsernameCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
+                    StandardUsernameCredentials.class, item, ACL.SYSTEM, Collections.emptyList());
             for (StandardUsernameCredentials standardUsernameCredential : standardUsernameCredentials) {
                 result.with(standardUsernameCredential);
             }


### PR DESCRIPTION
After a recent change, the administration UI of the plugin did not propose anymore all credentials that are available for the job. Just the Jenkins-wide credentials were available and not the folder ones anymore.