### PR TITLE
Documentation based on github and not wiki #patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.10.0
+
+Release date: _2021-01-15_
+
+- Several dependencies updates
+
+## 1.4.2
+
+Release date: _2019-12-16_
+
+- Also list credentials at folder level
+- Several dependencies updates
+
+## 1.3.4
+
+Release date: _2019-12-12_
+
+- Automated release
+- Fix pom pushed when tagged #patch
+
+## 1.3.1
+
+Release date: _2019-12-11_
+
+- Try to have coverage reported
+- Migrate to git hub actions
+- Preemptive auth
+
+## 1.2.3
+
+Release date: _2019-10-29_
+
+- Fix a documentation bug
+- Introduce preemptive authorization login if regular login failed
+
+## 1.2.2
+
+Release date: _2019-06-25_
+
+- Fix incorrect wiki URL
+
+## 1.2.1
+
+Release date: _2019-06-18_
+
+- First public version

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Join the chat at https://gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin](https://badges.gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin.svg)](https://gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jenkinsci/workflow-cps-global-lib-http-plugin)](https://dependabot.com)
 
-The current official plugin [workflow-cps-global-lib](https://github.com/jenkinsci/workflow-cps-global-lib-plugin/) does provide a way to retrieve shared libraries through a SCM, such as Git. The goal of this plugin is to provide another way to retrieve shared libraries via the @Library declaration in a Jenkinsfile.
+The current official plugin [workflow-cps-global-lib](https://github.com/jenkinsci/workflow-cps-global-lib-plugin/) does provide a way to retrieve shared libraries through a SCM, such as Git. The goal of this plugin is to provide another way to retrieve shared libraries via the *@Library* declaration in a Jenkinsfile.
 
-This is a way to separate to concerns : source code (SCM) and built artefacts (binaries). Built artefacts are immutable, tagged and often stored on a different kind of infrastructure. Since pipelines can be used to make production loads, it makes sense to host the libraries on a server with a production-level SLA for example. You can also make sure that your artefact repository is close to your pipelines and share the same SLA. Having your Jenkins and your artefact repository close limitsr latency and limits network issues.
+This is a way to separate to concerns : source code (SCM) and built artefacts (binaries). Built artefacts are immutable, tagged and often stored on a different kind of infrastructure. Since pipelines can be used to make production loads, it makes sense to host the libraries on a server with a production-level SLA for example. You can also make sure that your artefact repository is close to your pipelines and share the same SLA. Having your Jenkins and your artefact repository close limits latency and limits network issues.
 
 ## Context
 
@@ -147,7 +147,7 @@ In Administration / Folder / Pipeline configuration views:
 
 *In our case, we provide an Artifactory URL that retrieves shared libraries source code packaged into a zip archive.*
 
-The URL of the HTTP retriever is version-dynamic, it follows the Jenkins standard annotation ${library.<library_name>.version} that is afterwards replaced either by the default version provided by the admin, or the version specified by the user Jenkinsfile in the @Library annotation.
+The URL of the HTTP retriever is version-dynamic, it follows the Jenkins standard annotation *${library.\<library\_name\>.version}* that is afterwards replaced either by the default version provided by the admin, or the version specified by the user Jenkinsfile in the *@Library* annotation.
 
 ### Directly in the Jenkinsfile
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>1.10.0</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Shared Groovy Libraries through HTTP retrieval</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/HTTP+Shared+Libraries+Retriever+plugin</url>
+  <url>https://github.com/jenkinsci/workflow-cps-global-lib-http-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Following this: https://www.jenkins.io/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github