### PR TITLE
remove top level directory if zip is packaged that way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ work/
 http-shared-lib.iml
 publish.properties
 .factorypath
+# Intellij Files
+*.iml
 
 # This one is used to get the colors in the IDE, basically you do a ln -s Jenkinsfile Jenkinsfile.groovy and you get the colors, but we do not want to commit it :)
 Jenkinsfile.groovy

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.amadeus.jenkins.plugins</groupId>
   <artifactId>workflow-cps-global-lib-http</artifactId>
-  <version>1.13.0</version>
+  <version>1.14.0</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Shared Groovy Libraries through HTTP retrieval</name>
   <url>https://github.com/jenkinsci/workflow-cps-global-lib-http-plugin</url>
@@ -135,7 +135,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-    
+
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
+++ b/src/main/java/com/amadeus/jenkins/plugins/workflow/libs/HttpRetriever.java
@@ -225,7 +225,8 @@ public class HttpRetriever extends LibraryRetriever {
             }
             versionMessage += "From HTTP URL: " + sourceURL;
             listener.getLogger().println(versionMessage);
-
+            if (lease.path.list().size() == 1 && lease.path.list().get(0).isDirectory())
+                lease.path.list().get(0).moveAllChildrenTo(lease.path);
             // Copying it in build folder
             lease.path.copyRecursiveTo(target);
 


### PR DESCRIPTION
When the zip file being pulled down gets unzipped with a top level directory, the plugin errors with 

```
ERROR: Library decom-shared-libraries expected to contain at least one of src or vars directories
```

The logic I added will move the contents inside that folder into the workspace, and remove the top level folder from it. With this, I'm able to reach my library functions just fine.
